### PR TITLE
Enable multi-GPU model loading and avoid evaluation OOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ pip install -r requirements.txt
 ### Perform W4A4KV4 Quantization
 
 ```bash
-CUDA_VISIBLE_DEVICES=0 python main.py --model /LLMs/Llama-2-7B  --eval_ppl --dtype float16 \
+CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python main.py --model /LLMs/Llama-2-7B --device_map auto --eval_ppl --dtype float16 \
     --wbits 4 --w_sym  --abits 4 --kbits 4 --vbits 4  --true-sequential --act-order --disable_realq_replace \
     --pre_epochs 5 --epochs 5 --nsamples 256 --lac --lac_lr 3e-2 --lvr_lr 3e-3 --lscale_lr 3e-3 --batch_size 2  \
     --use_fpinps --upscale_mask 1111 --Rres_init Hadamard  --train_vo_rotation --train_o_scale \
     --tasks arc_challenge,arc_easy,boolq,hellaswag,openbookqa,piqa,winogrande
 ```
-Note: You can set --dtype bfloat16 in some model to have better performance
+Note: You can set `--dtype bfloat16` in some model to have better performance

--- a/main.py
+++ b/main.py
@@ -45,7 +45,9 @@ net_choices = [
 def evaluate(lm, args, logger):
     results = {}
     
-    if "llama" in args.net.lower() or "qwen" in args.net.lower():
+    if (
+        "llama" in args.net.lower() or "qwen" in args.net.lower()
+    ) and args.device_map == "cpu":
         lm.model = lm.model.to(lm.device)
    
     if args.eval_ppl:
@@ -133,6 +135,12 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", type=str, help="model name of model path")
     parser.add_argument("--net", type=str, default=None)
+    parser.add_argument(
+        "--device_map",
+        type=str,
+        default="auto",
+        help="device map for model loading, e.g. 'auto' or 'cpu'",
+    )
     parser.add_argument("--cache_dir", default="./cache", type=str, help="cache dir of dataset, leading to faster debug")
     parser.add_argument("--output_dir", default="../log/", type=str, help="direction of logging file")
     parser.add_argument("--scale_load_dir", default=None, type=str, help="direction for loading clipping paras")

--- a/models/LMClass.py
+++ b/models/LMClass.py
@@ -15,7 +15,10 @@ class LMClass(BaseLM):
         super().__init__()
 
         self.args = args
-        self._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if args.device_map == "cpu":
+            self._device = torch.device("cpu")
+        else:
+            self._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         self.model_name = args.model
         self.batch_size_per_gpu = args.batch_size
 
@@ -25,7 +28,9 @@ class LMClass(BaseLM):
         )
         print(self.model_config )
         self.tokenizer = AutoTokenizer.from_pretrained(args.model, use_fast=False,legacy=False)
-        self.model = AutoModelForCausalLM.from_pretrained(args.model, config=config, device_map='cpu',torch_dtype=args.dtype)
+        self.model = AutoModelForCausalLM.from_pretrained(
+            args.model, config=config, device_map=args.device_map, torch_dtype=args.dtype
+        )
         self.seqlen = self.model.config.max_position_embeddings
         self.model.eval()
         self.vocab_size = self.tokenizer.vocab_size


### PR DESCRIPTION
## Summary
- allow specifying `--device_map` to load models across GPUs
- avoid moving distributed models to a single device during evaluation
- update docs with example using multiple GPUs

## Testing
- `python -m py_compile main.py models/LMClass.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7b2218db08332820f94d93163c855