### PR TITLE
Fix device mismatch in rotary embedding wrapper

### DIFF
--- a/quantize/baseq.py
+++ b/quantize/baseq.py
@@ -141,6 +141,8 @@ def baseq(
             def forward(self, hidden_states, position_ids):
                 if self.module.inv_freq.device != hidden_states.device:
                     self.module.inv_freq = self.module.inv_freq.to(hidden_states.device)
+                if position_ids.device != hidden_states.device:
+                    position_ids = position_ids.to(hidden_states.device)
                 return self.module(hidden_states, position_ids)
 
         model.model.rotary_emb = RotaryWrapper(model.model.rotary_emb)


### PR DESCRIPTION
## Summary
- ensure `position_ids` tensor is moved to same device as hidden states in `RotaryWrapper`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7ba5e64108332bf868b89cc0a34a8